### PR TITLE
fix: form does not show when tab is opened

### DIFF
--- a/frontend/src/components/cme-form-view/cme-form-view.ts
+++ b/frontend/src/components/cme-form-view/cme-form-view.ts
@@ -54,10 +54,13 @@ export class FormView extends connect(store)(LitElement) {
   @state()
   private _tokenValues: {[name: string]: string | string[]} = {};
 
+  @state()
+  private _dynamicTemplate: string[] = [];
+
   @query('#form-view-repo-selector')
   private _repoSelector!: RepoSelector;
 
-  private _dynamicTemplate: string[] = [];
+
   private _reduceEmptyLines = true;
 
   connectedCallback(): void {


### PR DESCRIPTION
Convert the _dynamicTemplate variable to state to ensure it will trigger a re-rendering.