### PR TITLE
🐛 fix the bug that the extension does not work for the first commit

### DIFF
--- a/src/utils/GitService.ts
+++ b/src/utils/GitService.ts
@@ -127,8 +127,8 @@ class GitService {
 
     try {
       log = await repository.log({ maxEntries: limit });
-    } catch (er) {
-      throw er;
+    } catch {
+      return [];
     }
 
     if (!log) {


### PR DESCRIPTION
When creating the webview, the code in https://github.com/bendera/vscode-commit-message-editor/blob/6c6e0f3ca218b0e7706f429a5052869388a3a20e/src/commands/EditorController.ts#L56 tries to get the history messages of commits. However, for the first commit, there is no history message, and the corresponding 'get message' function will throw an error. I have changed the code such that it simply returns an empty.